### PR TITLE
Fix issues when using "long" on 64-bit builds

### DIFF
--- a/IBM_DB/ibm_db/ibm_db.h
+++ b/IBM_DB/ibm_db/ibm_db.h
@@ -149,7 +149,7 @@
 #ifdef PASE
 #define SQL_IS_INTEGER 0
 #define SQL_BEST_ROWID 0
-#define SQLLEN long
+#define SQLLEN SQLINTEGER
 #define SQLFLOAT double
 #endif
 


### PR DESCRIPTION
Closes kadler/python-ibmdb#3